### PR TITLE
Support new version of stability annotations

### DIFF
--- a/ScanExtensions.php
+++ b/ScanExtensions.php
@@ -204,7 +204,7 @@ class ScratchExtensions {
 				continue;
 			}
 			$comment = $refMethod->getDocComment();
-			if ( !preg_match('/@stable for overriding/', $comment ) ) { // function is not stable
+			if ( !preg_match('/@stable (for overriding|to override)/', $comment ) ) { // function is not stable
 				$unstableMethods[] = $method;
 			}
 		}


### PR DESCRIPTION
Adds support for new style "@stable to override" in addition to the old
style "@stable for overriding" annotation.